### PR TITLE
Export bucket replica link metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.6-alpine
 
 # Application directory
 WORKDIR /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=1.0.2
 prometheus-client>=0.6.0
 purestorage>=1.16.0
-purity-fb<=1.8.0
+purity-fb==1.9.1
 urllib3==1.24.2


### PR DESCRIPTION
This change leverages new features in purity-fb 1.9.1. Unfortunately using
this version of purity-fb requires using python 3.6.

This exports the following metrics for each object replica link on a flashblade which look like:

```
purefb_bucket_replica_links_replicating{direction="outbound",name="BUCKET_NAME",remote_bucket_name="REMOTE_BUCKET_NAME",remote_name="REMOTE_NAME"} 1.0
purefb_bucket_replica_links_paused{direction="outbound",name="BUCKET_NAME",remote_bucket_name="REMOTE_BUCKET_NAME",remote_name="REMOTE_NAME"} 0.0
purefb_bucket_replica_links_unhealthy{direction="outbound",name="BUCKET_NAME",remote_bucket_name="REMOTE_BUCKET_NAME",remote_name="REMOTE_NAME"} 0.0
purefb_bucket_replica_links_lag{direction="outbound",name="BUCKET_NAME",remote_bucket_name="REMOTE_BUCKET_NAME",remote_name="REMOTE_NAME"} 86511.0
purefb_bucket_replica_links_recovery_point{direction="outbound",name="BUCKET_NAME",remote_bucket_name="REMOTE_BUCKET_NAME",remote_name="REMOTE_NAME"} 1.590956502e+012
```

This closes #18 