### PR TITLE
Fixed issue with no volume groups

### DIFF
--- a/flasharray_collector/flasharray_collector.py
+++ b/flasharray_collector/flasharray_collector.py
@@ -43,8 +43,9 @@ class FlasharrayCollector():
             yield from ArraySpaceMetrics(self.fa).get_metrics()
             yield from ArrayPerformanceMetrics(self.fa).get_metrics()
         if self.request in ['all', 'volumes']:
-            yield from VolumeSpaceMetrics(self.fa).get_metrics()
-            yield from VolumePerformanceMetrics(self.fa).get_metrics()
+            volumes = self.fa.get_volumes()
+            yield from VolumeSpaceMetrics(volumes).get_metrics()
+            yield from VolumePerformanceMetrics(volumes).get_metrics()
         if self.request in ['all', 'hosts']:
             yield from HostSpaceMetrics(self.fa).get_metrics()
             yield from HostPerformanceMetrics(self.fa).get_metrics()

--- a/flasharray_collector/flasharray_metrics/host_volume_metrics.py
+++ b/flasharray_collector/flasharray_metrics/host_volume_metrics.py
@@ -1,0 +1,23 @@
+from prometheus_client.core import GaugeMetricFamily
+
+
+class HostVolumeMetrics():
+    """
+    Base class for mapping FlashArray hosts to connected volumes
+    """
+
+    def __init__(self, fa):
+        self.fa = fa
+        self.map_host_vol = GaugeMetricFamily('purefa_host_volumes_info',
+                                              'FlashArray host volumes connections',
+                                              labels=['host', 'naaid'])
+
+    def _map_host_vol(self):
+        for hv in self.fa.get_host_volumes():
+            self.map_host_vol.add_metric([hv['host'], hv['naaid']], 1)
+
+
+
+    def get_metrics(self):
+        self._map_host_vol()
+        yield self.map_host_vol

--- a/flasharray_collector/flasharray_metrics/volume_performance_metrics.py
+++ b/flasharray_collector/flasharray_metrics/volume_performance_metrics.py
@@ -8,8 +8,8 @@ class VolumePerformanceMetrics():
     Base class for FlashArray Prometheus volume performance metrics
     """
 
-    def __init__(self, fa):
-        self.fa = fa
+    def __init__(self, volumes):
+        self.volumes = volumes
         self.latency = GaugeMetricFamily('purefa_volume_performance_latency_usec',
                                          'FlashArray volume IO latency',
                                          labels = ['volume', 'naaid', 'pod', 'vgroup' ,'dimension'])
@@ -33,6 +33,8 @@ class VolumePerformanceMetrics():
                     e_name = p.split(e['name'])
                     if len(e_name) == 1:
                         e_name = ['/'] + e_name
+                    if 'vgroup' not in e.keys():
+                        e['vgroup'] = ''
                     metric.add_metric([e_name[1], e['naaid'], e_name[0], e['vgroup'], mapping[k]], e[k])
 
     def _latency(self):
@@ -40,7 +42,7 @@ class VolumePerformanceMetrics():
         Create volumes latency metrics of gauge type.
         """
         self._mk_metric(self.latency,
-                        self.fa.get_volumes(),
+                        self.volumes,
                         mappings.volume_latency_mapping)
 
     def _bandwidth(self):
@@ -48,7 +50,7 @@ class VolumePerformanceMetrics():
         Create volumes bandwidth metrics of gauge type.
         """
         self._mk_metric(self.bandwidth,
-                        self.fa.get_volumes(),
+                        self.volumes,
                         mappings.volume_bandwidth_mapping)
 
     def _iops(self):
@@ -56,7 +58,7 @@ class VolumePerformanceMetrics():
         Create IOPS bandwidth metrics of gauge type.
         """
         self._mk_metric(self.iops,
-                        self.fa.get_volumes(),
+                        self.volumes,
                         mappings.volume_iops_mapping)
 
     def get_metrics(self):

--- a/flasharray_collector/flasharray_metrics/volume_space_metrics.py
+++ b/flasharray_collector/flasharray_metrics/volume_space_metrics.py
@@ -7,8 +7,9 @@ class VolumeSpaceMetrics():
     Base class for FlashArray Prometheus volume space metrics
     """
 
-    def __init__(self, fa):
-        self.fa = fa
+    def __init__(self, volumes):
+        #self.fa = fa
+        self.volumes = volumes
         self.data_reduction = GaugeMetricFamily('purefa_volume_space_datareduction_ratio',
                                                 'FlashArray volumes data reduction ratio',
                                                 labels=['volume', 'naaid', 'pod', 'vgroup'],
@@ -32,18 +33,23 @@ class VolumeSpaceMetrics():
         Create metrics of gauge type for volume data reduction
         Metrics values can be iterated over.
         """
-        for v in self.fa.get_volumes():
+        for v in self.volumes:
             v_name = self.__split_vname(v['name'])
+            if 'vgroup' not in v.keys():
+                v['vgroup'] = ''
             self.data_reduction.add_metric([v_name[1], v['naaid'], v_name[0], v['vgroup']], v['data_reduction'] if v['data_reduction'] is not None else 0)
 
-
     def _size(self):
-        for v in self.fa.get_volumes():
+        for v in self.volumes:
+            if 'vgroup' not in v.keys():
+                v['vgroup'] = ''
             v_name = self.__split_vname(v['name'])
             self.size.add_metric([v_name[1], v['naaid'], v_name[0], v['vgroup']], v['size'] if v['size'] is not None else 0)
-
+            
     def _allocated(self):
-        for v in self.fa.get_volumes():
+        for v in self.volumes:
+            if 'vgroup' not in v.keys():
+                v['vgroup'] = ''
             v_name = self.__split_vname(v['name'])
             self.allocated.add_metric([v_name[1], v['naaid'], v_name[0], v['vgroup'], 'volumes'], v['volumes'] if v['volumes'] is not None else 0)
             self.allocated.add_metric([v_name[1], v['naaid'], v_name[0], v['vgroup'], 'snapshots'], v['snapshots'] if v['snapshots'] is not None else 0)

--- a/flasharray_collector/flasharray_metrics/volume_space_metrics.py
+++ b/flasharray_collector/flasharray_metrics/volume_space_metrics.py
@@ -8,7 +8,6 @@ class VolumeSpaceMetrics():
     """
 
     def __init__(self, volumes):
-        #self.fa = fa
         self.volumes = volumes
         self.data_reduction = GaugeMetricFamily('purefa_volume_space_datareduction_ratio',
                                                 'FlashArray volumes data reduction ratio',


### PR DESCRIPTION
Since we have FlashArrays with PODs only we have no volume groups on those. I quickly put this fix together.
Also noticed that the exporter called the API 6 times to get the same volume metrics. I've reduced this to 1 call and simply handing over the data to the different metric processors. Can be done for another few i think.