### PR TITLE
Expose total array capacity.

### DIFF
--- a/flashblade_collector/flashblade_metrics/array_space_metrics.py
+++ b/flashblade_collector/flashblade_metrics/array_space_metrics.py
@@ -7,13 +7,17 @@ class ArraySpaceMetrics():
     """
     def __init__(self, fb):
         self.fb = fb
+        self.capacity = GaugeMetricFamily('purefb_array_capacity_bytes',
+                                       'FlashBlade total capacity in bytes',
+                                       labels=[])
         self.space = GaugeMetricFamily('purefb_array_space_bytes',
-                                       'FlashBlade total space capacity',
+                                       'FlashBlade used space in bytes',
                                        labels=['dimension'])
         self.reduction = GaugeMetricFamily('purefb_array_space_data_reduction',
                                            'FlashBlade overall data reduction',
                                            labels=[])
         self.array_space = fb.get_array_space().space
+        self.array_capacity = fb.get_array_space().capacity
 
     def _space(self):
         """
@@ -26,6 +30,14 @@ class ArraySpaceMetrics():
         self.space.add_metric(['total_physical'], self.array_space.total_physical)
         self.space.add_metric(['snapshots'], self.array_space.snapshots)
 
+    def _capacity(self):
+        """
+        Create metrics of gauge type for array capacity indicator.
+        """
+        if self.array_capacity is  None:
+            return
+        self.capacity.add_metric([], self.array_capacity)
+
     def _reduction(self):
         """
         Create metrics of gauge type for array data redution indicator.
@@ -35,7 +47,9 @@ class ArraySpaceMetrics():
         self.reduction.add_metric([], self.array_space.data_reduction)
 
     def get_metrics(self):
+        self._capacity()
         self._space()
         self._reduction()
+        yield self.capacity
         yield self.space
         yield self.reduction


### PR DESCRIPTION
The current purefb_array_space_bytes metrics only show consumed space. In order to get space utilization as a percentage was also need total capacity as a metric. This adds the `purefb_array_capacity_bytes` metrics which makes this metric available.

This closes #33 