### PR TITLE
Pass ValueError exceptions to catch initialisation errors

### DIFF
--- a/flasharray_collector/flasharray_metrics/flasharray.py
+++ b/flasharray_collector/flasharray_metrics/flasharray.py
@@ -35,7 +35,7 @@ class FlashArray:
                 endpoint,
                 api_token=api_token,
                 user_agent='Purity_FA_Prometheus_exporter/1.0')
-        except purestorage.PureError:
+        except (purestorage.PureError,purestorage.ValueError):
             pass
 
         self.array = None


### PR DESCRIPTION
Not catching the ValueErrors exception causes a stacktrace dump further when attempting to access metrics, in the event of a bad API token or endpoint, rather than a simple exception message which indicates the FlashArray could not be initialized.  Passing the exception through at init makes this far more transparent for users